### PR TITLE
feat: Add Java TDD examples for common interview questions

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,5 +9,18 @@ O entrevistador já decorou o desafio que ele me passou, se ele me permitisse te
 
 [Link para as minhas entrevistas reais gravadas(todas as fases), sem cortes, apenas anonimização.](https://www.youtube.com/playlist?list=PLuL_sXVvkAaLvbKq4oSmzbgrn1iB3zwS-)
 
+## TDD Examples
+
+This repository also contains examples of common interview questions implemented using Test-Driven Development (TDD).
+
+*   **Reverse a String:**
+    *   Description: Reverses a given string.
+    *   Implementation: Developed using TDD principles, ensuring comprehensive test coverage for various scenarios including empty strings, single characters, palindromes, and strings with spaces or special characters.
+    *   Location: `src/main/java/ReverseString.java` (implementation) and `src/test/java/ReverseStringTest.java` (tests).
+
+*   **Valid Parentheses:**
+    *   Description: Checks if a string containing only parentheses '(', ')', '{', '}', '[' and ']' is valid. A string is valid if open brackets are closed by the same type of brackets and in the correct order.
+    *   Implementation: Developed using TDD principles, with tests covering empty strings, simple pairs, nested and sequential parentheses, as well as various invalid cases like mismatched types, unopened closing brackets, and unclosed opening brackets.
+    *   Location: `src/main/java/ValidParentheses.java` (implementation) and `src/test/java/ValidParenthesesTest.java` (tests).
 
 P.S. Sempre que falo de palindromo me refiro a testes genéricos que não atestam nada, como por exemplo, twosum, encontre o número mais próximo de zero numa lista, os leetcodes em geral. O maior exemplo desse tipo de teste que não atesta nada de fato é o palindromo, por isso chamo todos eles de palimdromos.

--- a/pom.xml
+++ b/pom.xml
@@ -20,6 +20,13 @@
             <version>5.8.1</version>
             <scope>test</scope>
         </dependency>
+        <!-- junit-jupiter-engine is required for Surefire to run JUnit 5 tests -->
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-engine</artifactId>
+            <version>5.8.1</version>
+            <scope>test</scope>
+        </dependency>
         <dependency>
             <groupId>org.assertj</groupId>
             <artifactId>assertj-core</artifactId>
@@ -27,5 +34,13 @@
             <scope>test</scope>
         </dependency>
     </dependencies>
-
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>2.22.2</version> <!-- Use a version that supports JUnit 5 -->
+            </plugin>
+        </plugins>
+    </build>
 </project>

--- a/src/main/java/ReverseString.java
+++ b/src/main/java/ReverseString.java
@@ -1,0 +1,9 @@
+public class ReverseString {
+
+    public static String reverse(String str) {
+        if (str == null) {
+            return null; // Or throw an IllegalArgumentException, depending on desired behavior
+        }
+        return new StringBuilder(str).reverse().toString();
+    }
+}

--- a/src/main/java/ValidParentheses.java
+++ b/src/main/java/ValidParentheses.java
@@ -1,0 +1,23 @@
+import java.util.Stack;
+
+public class ValidParentheses {
+
+    public static boolean isValid(String s) {
+        Stack<Character> stack = new Stack<>();
+        for (char c : s.toCharArray()) {
+            if (c == '(' || c == '{' || c == '[') {
+                stack.push(c);
+            } else if (c == ')' && !stack.isEmpty() && stack.peek() == '(') {
+                stack.pop();
+            } else if (c == '}' && !stack.isEmpty() && stack.peek() == '{') {
+                stack.pop();
+            } else if (c == ']' && !stack.isEmpty() && stack.peek() == '[') {
+                stack.pop();
+            } else {
+                // Non-parentheses characters or mismatched/unopened closing brackets
+                return false;
+            }
+        }
+        return stack.isEmpty();
+    }
+}

--- a/src/test/java/ReverseStringTest.java
+++ b/src/test/java/ReverseStringTest.java
@@ -1,0 +1,35 @@
+import org.junit.jupiter.api.Test;
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class ReverseStringTest {
+
+    @Test
+    void should_return_empty_string_for_empty_input() {
+        assertThat(ReverseString.reverse("")).isEqualTo("");
+    }
+
+    @Test
+    void should_return_same_character_for_single_character_input() {
+        assertThat(ReverseString.reverse("a")).isEqualTo("a");
+    }
+
+    @Test
+    void should_reverse_string_with_multiple_characters() {
+        assertThat(ReverseString.reverse("hello")).isEqualTo("olleh");
+    }
+
+    @Test
+    void should_handle_strings_with_leading_and_trailing_spaces() {
+        assertThat(ReverseString.reverse("  world  ")).isEqualTo("  dlrow  ");
+    }
+
+    @Test
+    void should_correctly_reverse_palindromic_string() {
+        assertThat(ReverseString.reverse("madam")).isEqualTo("madam");
+    }
+
+    @Test
+    void should_handle_string_with_numbers_and_symbols() {
+        assertThat(ReverseString.reverse("1a2b!")).isEqualTo("!b2a1");
+    }
+}

--- a/src/test/java/ValidParenthesesTest.java
+++ b/src/test/java/ValidParenthesesTest.java
@@ -1,0 +1,75 @@
+import org.junit.jupiter.api.Test;
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class ValidParenthesesTest {
+
+    @Test
+    void should_return_true_for_empty_string() {
+        assertThat(ValidParentheses.isValid("")).isTrue();
+    }
+
+    @Test
+    void should_return_true_for_simple_valid_pairs_like_round_brackets() {
+        assertThat(ValidParentheses.isValid("()")).isTrue();
+    }
+
+    @Test
+    void should_return_true_for_simple_valid_pairs_like_square_brackets() {
+        assertThat(ValidParentheses.isValid("[]")).isTrue();
+    }
+
+    @Test
+    void should_return_true_for_simple_valid_pairs_like_curly_brackets() {
+        assertThat(ValidParentheses.isValid("{}")).isTrue();
+    }
+
+    @Test
+    void should_return_true_for_nested_valid_parentheses() {
+        assertThat(ValidParentheses.isValid("({[]})")).isTrue();
+    }
+
+    @Test
+    void should_return_true_for_sequence_of_valid_parentheses() {
+        assertThat(ValidParentheses.isValid("()[]{}")).isTrue();
+    }
+
+    @Test
+    void should_return_false_for_unmatched_closing_bracket() {
+        assertThat(ValidParentheses.isValid("([)]")).isFalse();
+    }
+
+    @Test
+    void should_return_false_for_unmatched_opening_bracket() {
+        assertThat(ValidParentheses.isValid("((")).isFalse();
+    }
+
+    @Test
+    void should_return_false_for_single_opening_bracket() {
+        assertThat(ValidParentheses.isValid("{")).isFalse();
+    }
+
+    @Test
+    void should_return_false_for_single_closing_bracket() {
+        assertThat(ValidParentheses.isValid(")")).isFalse();
+    }
+
+    @Test
+    void should_return_false_for_mismatched_bracket_types() {
+        assertThat(ValidParentheses.isValid("(]")).isFalse();
+    }
+
+    @Test
+    void should_return_false_for_string_with_non_parentheses_characters() {
+        assertThat(ValidParentheses.isValid("(a)")).isFalse();
+    }
+
+    @Test
+    void should_return_false_for_valid_prefix_but_ending_with_open_bracket() {
+        assertThat(ValidParentheses.isValid("()(")).isFalse();
+    }
+
+    @Test
+    void should_return_false_for_valid_suffix_but_starting_with_closing_bracket() {
+        assertThat(ValidParentheses.isValid("())")).isFalse();
+    }
+}


### PR DESCRIPTION
Adds two new TDD examples to the Java project:

1.  **Reverse a String:**
    *   Provides an implementation to reverse a given string.
    *   Includes comprehensive unit tests covering various scenarios such as empty strings, single characters, palindromes, and strings with spaces or special characters.
    *   Located in `src/main/java/ReverseString.java` and `src/test/java/ReverseStringTest.java`.

2.  **Valid Parentheses:**
    *   Provides an implementation to validate strings containing parentheses '()[]{}'.
    *   Includes comprehensive unit tests covering empty strings, simple valid pairs, nested valid cases, and various invalid scenarios.
    *   Located in `src/main/java/ValidParentheses.java` and `src/test/java/ValidParenthesesTest.java`.

The `pom.xml` was also updated to ensure JUnit 5 tests are correctly discovered and executed by the Maven Surefire plugin.

The `README.md` has been updated to include descriptions and locations of these new examples.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a utility to reverse strings, including support for empty strings, palindromes, and special characters.
  - Introduced a tool to validate strings of parentheses for correct matching and order.

- **Tests**
  - Comprehensive tests added for both string reversal and parentheses validation, covering a wide range of edge cases.

- **Documentation**
  - Updated documentation to include examples and explanations for the new string reversal and parentheses validation features.

- **Chores**
  - Enhanced build configuration to support JUnit 5 testing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->